### PR TITLE
Changes for media-ingest-audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- **@steelbrain/media-ingest-audio**: Add `channelId` option to select specific audio channel from multi-channel streams
+  - Enables processing of individual channels from stereo/multi-channel audio sources
+  - Useful for stereo interview recordings, multi-channel audio interfaces, and professional audio setups
+  - Defaults to channel 0 (first channel) for backward compatibility
+
+- **@steelbrain/media-ingest-audio**: Add `sampleRate` option to configure AudioContext sample rate
+  - Allows custom sample rates from 8kHz to 96kHz+ for different use cases
+  - Supports telephony (8kHz), voice (16kHz default), music (44.1kHz), and professional audio (48kHz+)
+  - Automatically handles sample rate conversion from input to target rate
+  - Useful for optimizing quality vs. bandwidth based on application needs
+
+### Fixed
+
+- **@steelbrain/media-ingest-audio**: Fix audio worker continuing to send messages after stream closure
+  - Added try/catch around controller.enqueue to handle closed stream errors
+  - Properly cleanup resources when stream is cancelled while audio worker is still processing
+
+## [1.0.0] - 2025-01-23
+
+### Added
+
+- **@steelbrain/media-ingest-audio**: Convert MediaStream to 16kHz ReadableStream with configurable volume gain
+  - AudioWorklet-based processing for efficient real-time audio streaming
+  - Configurable gain parameter for volume normalization
+  - Zero-copy optimization when gain is 1.0 (default)
+  - Full support for modern bundlers (Webpack 5, Next.js, Vite)
+
+- **@steelbrain/media-speech-detection-web**: Production-ready voice activity detection using Silero VAD
+  - Official Silero VAD ONNX model implementation
+  - Zero-configuration defaults optimized for real-world usage
+  - Smooth speech transitions with lookback buffer
+  - Three-tier threshold system for robust detection
+  - Event-driven callbacks for speech start/end
+  - Support for .tee() patterns with noEmit option
+
+- **@steelbrain/media-buffer-speech**: Speech buffering with natural pause detection
+  - Accumulates audio chunks and releases after configurable pause duration
+  - Perfect for turn detection in conversations
+  - Buffer overflow protection with configurable limits
+  - Support for .tee() patterns with noEmit and onBuffered options
+
+- **Example Next.js Application**: Complete demonstration of all three packages
+  - Real-time speech detection visualization
+  - Audio recording and playback for VAD verification
+  - Sample rate debugging and compatibility checks
+  - Proper resource cleanup patterns
+
+### Technical Details
+
+- Monorepo structure with yarn workspaces
+- TypeScript with strict mode enabled
+- Build system using zshy for automatic package.json management
+- Minimum Node.js version: 22.0.0
+- Comprehensive test suites using Vitest
+- Production-ready error handling and resource management

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,9 @@ example-nextjs → Demonstration app (Next.js 15 + React 19)
 
 ### MediaStreamToReadableStream
 - **Location**: `projects/media-ingest-audio/src/index.ts`
-- **Purpose**: Converts browser MediaStream to ReadableStream using MediaRecorder API
-- **Pattern**: Configurable WebM/Opus encoding with chunk streaming
+- **Purpose**: Converts browser MediaStream to ReadableStream with configurable sample rate (default: 16kHz)
+- **Pattern**: AudioWorklet-based processing with configurable gain, channel selection, and sample rate
+- **Features**: Volume gain control, specific channel extraction from multi-channel streams, configurable sample rate
 
 ### Speech Detection Functions
 - **Location**: `projects/media-speech-detection-web/src/index.ts`
@@ -200,8 +201,21 @@ const mediaStream = await navigator.mediaDevices.getUserMedia({
   audio: RECOMMENDED_AUDIO_CONSTRAINTS
 });
 
-// Convert to 16kHz ReadableStream
+// Convert to 16kHz ReadableStream (default)
 const audioStream = await ingestAudioStream(mediaStream);
+
+// With volume boost for quiet microphones
+const boostedStream = await ingestAudioStream(mediaStream, { gain: 2.0 });
+
+// Process specific channel from stereo/multi-channel audio
+const leftChannel = await ingestAudioStream(mediaStream, { channelId: 0 });  // Left channel
+const rightChannel = await ingestAudioStream(mediaStream, { channelId: 1 }); // Right channel
+
+// Use custom sample rate (e.g., 48kHz)
+const highQualityStream = await ingestAudioStream(mediaStream, { sampleRate: 48000 });
+
+// Combine options: boost specific channel with custom sample rate
+const boostedRightChannel = await ingestAudioStream(mediaStream, { gain: 1.5, channelId: 1, sampleRate: 44100 });
 
 // Create speech filter with zero configuration - works great with defaults!
 const speechTransform = speechFilter({

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ### [@steelbrain/media-ingest-audio](./projects/media-ingest-audio)
 
-Convert MediaStream audio to 16kHz ReadableStream for downstream processing.
+Convert MediaStream audio to ReadableStream with configurable sample rate for downstream processing.
 
 ```bash
 npm install @steelbrain/media-ingest-audio
@@ -27,10 +27,11 @@ npm install @steelbrain/media-ingest-audio
 
 **Key Features:**
 - 🎙️ Automatic microphone access with optimal constraints
-- 🔄 16kHz resampling via AudioWorklet
+- 🔄 Configurable sample rate via AudioWorklet (default: 16kHz)
 - 🎚️ Configurable volume gain for microphone normalization
 - 📊 Preserves audio quality during conversion
 - 🛡️ Handles sample rate conversion transparently
+- 🎵 Support for various sample rates (8kHz to 96kHz+)
 
 ```typescript
 import { ingestAudioStream, RECOMMENDED_AUDIO_CONSTRAINTS } from '@steelbrain/media-ingest-audio';
@@ -40,10 +41,13 @@ const mediaStream = await navigator.mediaDevices.getUserMedia({
 });
 
 const audioStream = await ingestAudioStream(mediaStream);
-// Returns ReadableStream<Float32Array> of 16kHz audio samples
+// Returns ReadableStream<Float32Array> of 16kHz audio samples (default)
 
 // With volume gain for quiet microphones
 const boostedStream = await ingestAudioStream(mediaStream, { gain: 2.0 });
+
+// With custom sample rate for music quality
+const musicStream = await ingestAudioStream(mediaStream, { sampleRate: 44100 });
 ```
 
 ### [@steelbrain/media-speech-detection-web](./projects/media-speech-detection-web)
@@ -134,7 +138,7 @@ const mediaStream = await navigator.mediaDevices.getUserMedia({
   audio: RECOMMENDED_AUDIO_CONSTRAINTS
 });
 
-// 2. Convert to 16kHz stream with optional volume boost
+// 2. Convert to 16kHz stream (default) with optional volume boost
 const audioStream = await ingestAudioStream(mediaStream, { gain: 1.5 });
 
 // 3. Create speech detection filter
@@ -291,8 +295,8 @@ Process speech segments for sentiment analysis, keyword detection, or conversati
 
 ### Audio Processing
 - **Input Format**: Any MediaStream (typically microphone)
-- **Processing Rate**: 16kHz PCM mono (industry standard)
-- **Frame Size**: 512 samples (32ms frames)
+- **Processing Rate**: Configurable sample rate (default: 16kHz PCM mono)
+- **Frame Size**: 512 samples (32ms frames at 16kHz)
 - **Context Window**: 64 samples for model accuracy
 
 ### Speech Detection Model

--- a/projects/media-buffer-speech/src/index.ts
+++ b/projects/media-buffer-speech/src/index.ts
@@ -136,16 +136,10 @@ export function bufferSpeech<T>(options: BufferSpeechOptions = {}): TransformStr
       }, durationMs);
     },
 
-    flush: () => {
-      debugLog('Stream ending, discarding final buffer without enqueuing');
-      // Clean up timer and buffer without enqueuing
-      if (pauseTimer) {
-        clearTimeout(pauseTimer);
-        pauseTimer = null;
-      }
-      buffer = [];
-      bufferStartTime = null;
-      chunkCount = 0;
+    flush: (controller) => {
+      debugLog('Stream ending, releasing final buffer');
+      // Release any buffered content
+      releaseBuffer(controller);
     },
   });
 }

--- a/projects/media-ingest-audio/README.md
+++ b/projects/media-ingest-audio/README.md
@@ -1,6 +1,6 @@
 # @steelbrain/media-ingest-audio
 
-Convert MediaStream audio to 16kHz ReadableStream for downstream processing.
+Convert MediaStream audio to ReadableStream with configurable sample rate for downstream processing.
 
 ## Installation
 
@@ -20,7 +20,7 @@ const mediaStream = await navigator.mediaDevices.getUserMedia({
   audio: RECOMMENDED_AUDIO_CONSTRAINTS
 });
 
-// Basic usage - convert to 16kHz audio stream
+// Basic usage - convert to 16kHz audio stream (default)
 const audioStream = await ingestAudioStream(mediaStream);
 
 // With volume gain - boost quiet microphones
@@ -29,9 +29,23 @@ const boostedAudioStream = await ingestAudioStream(mediaStream, { gain: 2.0 });
 // With volume reduction - lower loud inputs
 const quietAudioStream = await ingestAudioStream(mediaStream, { gain: 0.5 });
 
+// Use custom sample rate (e.g., 48kHz for high quality)
+const highQualityStream = await ingestAudioStream(mediaStream, { sampleRate: 48000 });
+
+// Process specific channel from stereo audio
+const leftChannelStream = await ingestAudioStream(mediaStream, { channelId: 0 });  // Left channel
+const rightChannelStream = await ingestAudioStream(mediaStream, { channelId: 1 }); // Right channel
+
+// Combine options: boost right channel with custom sample rate
+const boostedRightChannel = await ingestAudioStream(mediaStream, {
+  gain: 2.0,
+  channelId: 1,
+  sampleRate: 44100
+});
+
 // Read audio data
 const reader = audioStream.getReader();
-const { value } = await reader.read(); // Float32Array of 16kHz samples
+const { value } = await reader.read(); // Float32Array of audio samples at configured sample rate
 
 // Clean up when done
 await reader.cancel();
@@ -41,11 +55,11 @@ await reader.cancel();
 
 ### `ingestAudioStream(mediaStream: MediaStream, options?: AudioIngestOptions): Promise<ReadableStream<Float32Array>>`
 
-Converts a MediaStream into a ReadableStream of 16kHz audio data with optional volume gain.
+Converts a MediaStream into a ReadableStream of audio data with configurable sample rate and optional volume gain.
 
 - **mediaStream**: MediaStream containing audio tracks
 - **options**: Optional configuration (see `AudioIngestOptions`)
-- **Returns**: ReadableStream that yields Float32Array chunks of 16kHz audio samples
+- **Returns**: ReadableStream that yields Float32Array chunks of audio samples at the configured sample rate
 
 ### `AudioIngestOptions`
 
@@ -55,29 +69,32 @@ Configuration options for audio ingestion:
 interface AudioIngestOptions {
   /** Volume gain multiplier. 1.0 = no change, 2.0 = double volume, 0.5 = half volume. Default: 1.0 */
   gain?: number;
+  /** Audio channel index to use (0-based). Default: 0 (first channel) */
+  channelId?: number;
+  /** Sample rate for the AudioContext. Default: 16000 */
+  sampleRate?: number;
 }
 ```
 
 ### `RECOMMENDED_AUDIO_CONSTRAINTS`
 
-Optimal audio constraints for voice processing:
+Optimal audio constraints for raw voice capture:
 
 ```typescript
 {
   sampleRate: 16000,
-  channelCount: 1,
-  echoCancellation: true,
-  noiseSuppression: true
+  channelCount: 1
 }
 ```
 
 ## How it Works
 
-1. Creates an AudioContext with 16kHz sample rate
+1. Creates an AudioContext with configurable sample rate (default: 16kHz)
 2. Uses AudioWorklet for efficient audio processing with optional volume gain
-3. Automatically handles sample rate conversion from input to 16kHz
+3. Automatically handles sample rate conversion from input to target rate
 4. Applies volume gain multiplier to audio samples when specified
-5. Preserves all audio channels (mono/stereo) in the output stream
+5. Selects specific audio channel from multi-channel streams when channelId is specified
+6. Defaults to first channel (index 0) for consistent mono output
 
 ## Use Cases
 
@@ -108,6 +125,52 @@ const gain = micLabel.includes('built-in') ? 1.8 : // Built-in mics are usually 
              1.0; // External mics are usually well-calibrated
 
 const audioStream = await ingestAudioStream(mediaStream, { gain });
+```
+
+### 🎛️ **Stereo Channel Selection**
+```typescript
+// Process specific channels from stereo microphones
+const leftChannel = await ingestAudioStream(mediaStream, { channelId: 0 });
+const rightChannel = await ingestAudioStream(mediaStream, { channelId: 1 });
+
+// Useful for stereo interview recordings where each person has their own channel
+const interviewer = await ingestAudioStream(mediaStream, { channelId: 0, gain: 1.2 });
+const interviewee = await ingestAudioStream(mediaStream, { channelId: 1, gain: 1.5 });
+```
+
+### 🎪 **Multi-Channel Audio Interfaces**
+```typescript
+// Professional audio interfaces may have many channels
+const channel3 = await ingestAudioStream(mediaStream, { channelId: 2 }); // Third input
+const channel4 = await ingestAudioStream(mediaStream, { channelId: 3 }); // Fourth input
+
+// Process each band member's microphone separately
+const vocals = await ingestAudioStream(mediaStream, { channelId: 0, gain: 1.3 });
+const guitar = await ingestAudioStream(mediaStream, { channelId: 1, gain: 0.9 });
+const bass = await ingestAudioStream(mediaStream, { channelId: 2, gain: 1.1 });
+const drums = await ingestAudioStream(mediaStream, { channelId: 3, gain: 0.8 });
+```
+
+### 🎵 **Sample Rate Configuration**
+```typescript
+// Default 16kHz for voice applications (VAD, speech recognition)
+const voiceStream = await ingestAudioStream(mediaStream);
+
+// 44.1kHz for music quality
+const musicStream = await ingestAudioStream(mediaStream, { sampleRate: 44100 });
+
+// 48kHz for professional audio
+const studioStream = await ingestAudioStream(mediaStream, { sampleRate: 48000 });
+
+// 8kHz for telephony applications
+const phoneStream = await ingestAudioStream(mediaStream, { sampleRate: 8000 });
+
+// High sample rate with specific channel and gain
+const highQualityVocals = await ingestAudioStream(mediaStream, {
+  sampleRate: 96000,
+  channelId: 0,
+  gain: 1.2
+});
 ```
 
 ## Performance

--- a/projects/media-ingest-audio/__tests__/index.test.ts
+++ b/projects/media-ingest-audio/__tests__/index.test.ts
@@ -36,8 +36,6 @@ describe('RECOMMENDED_AUDIO_CONSTRAINTS', () => {
     expect(RECOMMENDED_AUDIO_CONSTRAINTS).toEqual({
       sampleRate: 16000,
       channelCount: 1,
-      echoCancellation: true,
-      noiseSuppression: true,
     });
   });
 
@@ -102,6 +100,7 @@ describe('ingestAudioStream', () => {
     expect(mockAudioWorkletNode).toHaveBeenCalledWith(expect.anything(), 'resampler-processor', {
       processorOptions: {
         gain: 2.5,
+        channelId: 0,
       },
     });
   });
@@ -116,6 +115,7 @@ describe('ingestAudioStream', () => {
     expect(mockAudioWorkletNode).toHaveBeenCalledWith(expect.anything(), 'resampler-processor', {
       processorOptions: {
         gain: 1.0,
+        channelId: 0,
       },
     });
   });
@@ -130,6 +130,7 @@ describe('ingestAudioStream', () => {
     expect(mockAudioWorkletNode).toHaveBeenCalledWith(expect.anything(), 'resampler-processor', {
       processorOptions: {
         gain: 1.0,
+        channelId: 0,
       },
     });
   });
@@ -144,6 +145,7 @@ describe('ingestAudioStream', () => {
     expect(mockAudioWorkletNode).toHaveBeenCalledWith(expect.anything(), 'resampler-processor', {
       processorOptions: {
         gain: 0,
+        channelId: 0,
       },
     });
   });
@@ -158,6 +160,7 @@ describe('ingestAudioStream', () => {
     expect(mockAudioWorkletNode).toHaveBeenCalledWith(expect.anything(), 'resampler-processor', {
       processorOptions: {
         gain: 0.25,
+        channelId: 0,
       },
     });
   });

--- a/projects/media-ingest-audio/src/audio-processor.ts
+++ b/projects/media-ingest-audio/src/audio-processor.ts
@@ -1,11 +1,14 @@
 // Simple AudioWorklet processor for processing audio at 16kHz with volume gain
 class ResamplerProcessor extends AudioWorkletProcessor {
   private gain: number;
+  private channelId: number;
 
   constructor(options?: AudioWorkletNodeOptions) {
     super();
     // Get gain from processor options, default to 1.0 (no change)
     this.gain = options?.processorOptions?.gain ?? 1.0;
+    // Get channel ID from processor options, default to 0 (first channel)
+    this.channelId = options?.processorOptions?.channelId ?? 0;
   }
 
   process(inputs: Float32Array[][], _outputs: Float32Array[][], _parameters: { [name: string]: Float32Array }): boolean {
@@ -14,29 +17,33 @@ class ResamplerProcessor extends AudioWorkletProcessor {
       return true;
     }
 
-    // Apply gain and pass through the audio data - AudioContext handles 16kHz conversion
-    for (let channel = 0; channel < input.length; channel++) {
-      const channelData = input[channel];
-      if (channelData.length > 0) {
-        // Apply volume gain if not 1.0 (optimization: skip multiplication when no gain change)
-        let processedData: Float32Array;
-        if (this.gain !== 1.0) {
-          // Create new array and apply gain
-          processedData = new Float32Array(channelData.length);
-          for (let i = 0; i < channelData.length; i++) {
-            processedData[i] = channelData[i] * this.gain;
-          }
-        } else {
-          // No gain change, pass through original data
-          processedData = channelData;
-        }
+    // Ensure the requested channel exists
+    if (this.channelId >= input.length) {
+      // If requested channel doesn't exist, fallback to first channel
+      this.channelId = 0;
+    }
 
-        this.port.postMessage({
-          type: 'audioData',
-          data: processedData,
-          channel: channel,
-        });
+    // Process only the specified channel
+    const channelData = input[this.channelId];
+    if (channelData && channelData.length > 0) {
+      // Apply volume gain if not 1.0 (optimization: skip multiplication when no gain change)
+      let processedData: Float32Array;
+      if (this.gain !== 1.0) {
+        // Create new array and apply gain
+        processedData = new Float32Array(channelData.length);
+        for (let i = 0; i < channelData.length; i++) {
+          processedData[i] = channelData[i] * this.gain;
+        }
+      } else {
+        // No gain change, pass through original data
+        processedData = channelData;
       }
+
+      this.port.postMessage({
+        type: 'audioData',
+        data: processedData,
+        channel: this.channelId,
+      });
     }
 
     return true;

--- a/projects/media-ingest-audio/src/index.ts
+++ b/projects/media-ingest-audio/src/index.ts
@@ -4,8 +4,6 @@
 export const RECOMMENDED_AUDIO_CONSTRAINTS: MediaTrackConstraints = Object.freeze({
   sampleRate: 16000,
   channelCount: 1,
-  echoCancellation: true,
-  noiseSuppression: true,
 });
 
 /**
@@ -14,14 +12,18 @@ export const RECOMMENDED_AUDIO_CONSTRAINTS: MediaTrackConstraints = Object.freez
 export interface AudioIngestOptions {
   /** Volume gain multiplier. 1.0 = no change, 2.0 = double volume, 0.5 = half volume. Default: 1.0 */
   gain?: number;
+  /** Audio channel index to use (0-based). Default: 0 (first channel) */
+  channelId?: number;
+  /** Sample rate for the AudioContext. Default: 16000 */
+  sampleRate?: number;
 }
 
 /**
- * Converts a MediaStream into a ReadableStream of 16kHz audio data
+ * Converts a MediaStream into a ReadableStream of audio data at the specified sample rate
  *
  * @example
  * ```typescript
- * // Basic usage
+ * // Basic usage (defaults to first channel, 16kHz)
  * const audioStream = await ingestAudioStream(mediaStream);
  *
  * // With volume boost
@@ -29,6 +31,15 @@ export interface AudioIngestOptions {
  *
  * // With volume reduction
  * const audioStream = await ingestAudioStream(mediaStream, { gain: 0.5 });
+ *
+ * // Use second channel (index 1) of stereo audio
+ * const audioStream = await ingestAudioStream(mediaStream, { channelId: 1 });
+ *
+ * // Use custom sample rate (e.g., 48kHz)
+ * const audioStream = await ingestAudioStream(mediaStream, { sampleRate: 48000 });
+ *
+ * // Combine options: use second channel with volume boost and custom sample rate
+ * const audioStream = await ingestAudioStream(mediaStream, { gain: 2.0, channelId: 1, sampleRate: 44100 });
  * ```
  */
 export async function ingestAudioStream(mediaStream: MediaStream, options: AudioIngestOptions = {}): Promise<ReadableStream<Float32Array>> {
@@ -54,23 +65,29 @@ export async function ingestAudioStream(mediaStream: MediaStream, options: Audio
   return new ReadableStream<Float32Array>({
     start: async controller => {
       try {
-        // Use 16kHz sample rate like the example snippet
-        audioContext = new AudioContext({ sampleRate: 16000 });
+        // Use configurable sample rate, default to 16kHz
+        audioContext = new AudioContext({ sampleRate: options.sampleRate ?? 16000 });
 
         // Load the AudioWorklet module
         await audioContext.audioWorklet.addModule(new URL('./audio-processor', import.meta.url));
 
-        // Create the worklet node with gain parameter
+        // Create the worklet node with gain and channelId parameters
         workletNode = new AudioWorkletNode(audioContext, 'resampler-processor', {
           processorOptions: {
             gain: options.gain ?? 1.0,
+            channelId: options.channelId ?? 0,
           },
         });
 
         // Listen for processed audio data
         workletNode.port.onmessage = event => {
           if (event.data.type === 'audioData') {
-            controller.enqueue(event.data.data);
+            try {
+              controller.enqueue(event.data.data);
+            } catch (error) {
+              // Stream has been closed/cancelled, cleanup
+              cleanup();
+            }
           }
         };
 


### PR DESCRIPTION
### Added

- **@steelbrain/media-ingest-audio**: Add `channelId` option to select specific audio channel from multi-channel streams
  - Enables processing of individual channels from stereo/multi-channel audio sources
  - Useful for stereo interview recordings, multi-channel audio interfaces, and professional audio setups
  - Defaults to channel 0 (first channel) for backward compatibility

- **@steelbrain/media-ingest-audio**: Add `sampleRate` option to configure AudioContext sample rate
  - Allows custom sample rates from 8kHz to 96kHz+ for different use cases
  - Supports telephony (8kHz), voice (16kHz default), music (44.1kHz), and professional audio (48kHz+)
  - Automatically handles sample rate conversion from input to target rate
  - Useful for optimizing quality vs. bandwidth based on application needs

### Fixed

- **@steelbrain/media-ingest-audio**: Fix audio worker continuing to send messages after stream closure
  - Added try/catch around controller.enqueue to handle closed stream errors
  - Properly cleanup resources when stream is cancelled while audio worker is still processing
